### PR TITLE
fix barrel link

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,8 +14,8 @@
 {deps, [
     {lager, "2.*", {git, "git://github.com/basho/lager.git",
                         "2.0.3"}},
-    {barrel, ".*", {git, "git://github.com/benoitc/barrel.git",
-                    {branch, "master"}}},
+    {barrel, ".*", {git, "git://github.com/benoitc-attic/barrel_tcp.git",
+                        {branch, "master"}}},
     {worker_pool, "1.*", {git, "http://github.com/inaka/worker_pool",
                            {tag, "1.0.2"}}}
 ]}.


### PR DESCRIPTION
Sorry I broke your project yesterday. Thanks to @essen that noticed it.

As a short explanation, I will no longer use the name `barrel` for this project. It has been renamed for now `barrel_tcp`and temporarily moved to another repository. I will provides you another more complete PR once the project will find its new state sometimes next week.